### PR TITLE
feat TeamLeaderLogic

### DIFF
--- a/src/main/java/com/springboot/publicplace/controller/TeamController.java
+++ b/src/main/java/com/springboot/publicplace/controller/TeamController.java
@@ -4,6 +4,7 @@ import com.springboot.publicplace.dto.ResultDto;
 import com.springboot.publicplace.dto.request.TeamRequestDto;
 import com.springboot.publicplace.dto.response.TeamListResponseDto;
 import com.springboot.publicplace.dto.response.TeamResponseDto;
+import com.springboot.publicplace.dto.response.TeamRoleResponseDto;
 import com.springboot.publicplace.service.TeamService;
 import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
@@ -61,5 +62,12 @@ public class TeamController {
 
         List<TeamListResponseDto> teams = teamService.getTeamsByCriteria(sortBy, teamName);
         return ResponseEntity.status(HttpStatus.OK).body(teams);
+    }
+
+    @PostMapping("/leader/{teamId}")
+    public ResponseEntity<TeamRoleResponseDto> checkTeamRole(HttpServletRequest servletRequest,
+                                                             @PathVariable Long teamId) {
+        TeamRoleResponseDto teamRoleResponseDto = teamService.checkTeamRole(servletRequest,teamId);
+        return ResponseEntity.status(HttpStatus.OK).body(teamRoleResponseDto);
     }
 }

--- a/src/main/java/com/springboot/publicplace/dto/response/TeamRoleResponseDto.java
+++ b/src/main/java/com/springboot/publicplace/dto/response/TeamRoleResponseDto.java
@@ -1,0 +1,16 @@
+package com.springboot.publicplace.dto.response;
+
+import com.springboot.publicplace.entity.RoleType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TeamRoleResponseDto {
+    private RoleType role;
+    private boolean isLeader;
+}

--- a/src/main/java/com/springboot/publicplace/service/TeamService.java
+++ b/src/main/java/com/springboot/publicplace/service/TeamService.java
@@ -4,6 +4,7 @@ import com.springboot.publicplace.dto.ResultDto;
 import com.springboot.publicplace.dto.request.TeamRequestDto;
 import com.springboot.publicplace.dto.response.TeamListResponseDto;
 import com.springboot.publicplace.dto.response.TeamResponseDto;
+import com.springboot.publicplace.dto.response.TeamRoleResponseDto;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
@@ -21,4 +22,5 @@ public interface TeamService{
 
     ResultDto checkTeamName (String teamName);
 
+    TeamRoleResponseDto checkTeamRole(HttpServletRequest servletRequest, Long teamId);
 }


### PR DESCRIPTION
- 팀안에서의 역할을 확인하는 로직 /api/v1/team/leader/{teamId}

1. 회장인 경우 {
  "role": "회장",
  "leader": true
}
2. 팀원인 경우 {
  "role": "팀원",
  "leader": false
}
3. 그외 아무것도 아닌경우 {
  "success": false,
  "code": 403,
  "msg": "User Not In Team: 팀에 가입된 사용자가 아닙니다."
}