### PR TITLE
fix S3 Error

### DIFF
--- a/src/main/java/com/springboot/publicplace/service/impl/TeamServiceImpl.java
+++ b/src/main/java/com/springboot/publicplace/service/impl/TeamServiceImpl.java
@@ -176,6 +176,43 @@ public class TeamServiceImpl implements TeamService {
         );
     }
 
+//    @Override
+//    public List<TeamResponseDto> getRandomTeamList(HttpServletRequest servletRequest) {
+//        List<Team> teams = teamRepository.findAll();
+//        return teams.stream()
+//                .map(team -> {
+//                    // 팀원 리스트 생성
+//                    List<MemberDto> members = team.getTeamUsers().stream()
+//                            .map(teamUser -> new MemberDto(
+//                                    teamUser.getUser().getName(),
+//                                    teamUser.getUser().getNickname(),
+//                                    teamUser.getUser().getPosition(),
+//                                    teamUser.getRole(),
+//                                    teamUser.getUser().getAgeRange()
+//                            ))
+//                            .collect(Collectors.toList());
+//
+//                    // 팀원 수 계산
+//                    Long teamMemberCount = (long) members.size();
+//
+//                    // TeamResponseDto 생성 및 반환
+//                    return TeamResponseDto.builder()
+//                            .teamId(team.getTeamId())
+//                            .teamName(team.getTeamName())
+//                            .teamInfo(team.getTeamInfo())
+//                            .createdAt(team.getCreatedAt())
+//                            .teamLocation(team.getTeamLocation())
+//                            .latitude(team.getLatitude())
+//                            .longitude(team.getLongitude())
+//                            .teamImg(team.getTeamImg())
+//                            .activityDays(team.getActivityDays())
+//                            .teamMemberCount(teamMemberCount)  // 팀원 수 포함
+//                            .members(members)  // 팀원 리스트 포함
+//                            .build();
+//                })
+//                .collect(Collectors.toList());
+//    }
+
     @Override
     public List<GPTTeamListDto> getTeamList(HttpServletRequest servletRequest) {
         // 모든 팀을 가져옴
@@ -199,7 +236,6 @@ public class TeamServiceImpl implements TeamService {
                             .build();
                 })
                 .collect(Collectors.toList());
-
         return teamLists;
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,6 +22,8 @@ openai.api.url=https://api.openai.com/v1/chat/completions
 
 # S3 Bucket
 cloud.aws.s3.bucket=promfren-bucket
+cloud.aws.credentials.access-key=${AWS_ACCESS_KEY}
+cloud.aws.credentials.secret-key=${AWS_SECRET_KEY}
 
 spring.servlet.multipart.enabled=true
 spring.servlet.multipart.max-file-size=5MB


### PR DESCRIPTION
- "알 수 없는 오류가 발생했습니다: Unable to load AWS credentials from any provider in the chain: [com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper@60a2b744: AWS_EC2_METADATA_DISABLED is set to true, not loading credentials from EC2 Instance Metadata service, com.amazonaws.auth.profile.ProfileCredentialsProvider@22316864: profile file cannot be null]" 에러 해결을 하기 위해 Github Setting -> Secret -> Actions에 넣었던 변수를 cloud.aws.credentials.~~key에 넣었다

![{051394A7-DBE8-4858-A413-B20067E9CBEE}](https://github.com/user-attachments/assets/88bd89c3-d050-4de0-9ab6-b7d25cbadf3c)
