### PR TITLE
fix TeamService

### DIFF
--- a/src/main/java/com/springboot/publicplace/controller/TeamController.java
+++ b/src/main/java/com/springboot/publicplace/controller/TeamController.java
@@ -2,10 +2,7 @@ package com.springboot.publicplace.controller;
 
 import com.springboot.publicplace.dto.ResultDto;
 import com.springboot.publicplace.dto.request.TeamRequestDto;
-import com.springboot.publicplace.dto.response.GPTTeamListDto;
-import com.springboot.publicplace.dto.response.TeamListResponseDto;
-import com.springboot.publicplace.dto.response.TeamResponseDto;
-import com.springboot.publicplace.dto.response.TeamRoleResponseDto;
+import com.springboot.publicplace.dto.response.*;
 import com.springboot.publicplace.service.TeamService;
 import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
@@ -50,8 +47,8 @@ public class TeamController {
     }
 
     @GetMapping("/getTeamList")
-    public ResponseEntity<List<GPTTeamListDto>> getTeamList(HttpServletRequest servletRequest) {
-        List<GPTTeamListDto> teamList = teamService.getTeamList(servletRequest);
+    public ResponseEntity<List<TeamRandomListDto>> getTeamList(HttpServletRequest servletRequest) {
+        List<TeamRandomListDto> teamList = teamService.getTeamList(servletRequest);
         return ResponseEntity.status(HttpStatus.OK).body(teamList);
     }
 

--- a/src/main/java/com/springboot/publicplace/dto/response/TeamRandomListDto.java
+++ b/src/main/java/com/springboot/publicplace/dto/response/TeamRandomListDto.java
@@ -1,0 +1,23 @@
+package com.springboot.publicplace.dto.response;
+
+import com.springboot.publicplace.dto.MemberDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TeamRandomListDto {
+    private Long teamId;
+    private String teamName;
+    private LocalDateTime createdAt;
+    private String teamLocation;
+    private String teamImg;
+    private Long teamMemberCount;
+    private double averageAge;
+}

--- a/src/main/java/com/springboot/publicplace/service/TeamService.java
+++ b/src/main/java/com/springboot/publicplace/service/TeamService.java
@@ -2,10 +2,7 @@ package com.springboot.publicplace.service;
 
 import com.springboot.publicplace.dto.ResultDto;
 import com.springboot.publicplace.dto.request.TeamRequestDto;
-import com.springboot.publicplace.dto.response.GPTTeamListDto;
-import com.springboot.publicplace.dto.response.TeamListResponseDto;
-import com.springboot.publicplace.dto.response.TeamResponseDto;
-import com.springboot.publicplace.dto.response.TeamRoleResponseDto;
+import com.springboot.publicplace.dto.response.*;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
@@ -17,7 +14,9 @@ public interface TeamService{
 
     TeamResponseDto getTeamInfo(Long teamId);
 
-    List<GPTTeamListDto> getTeamList(HttpServletRequest servletRequest);
+    List<TeamRandomListDto> getTeamList(HttpServletRequest servletRequest);
+
+    List<GPTTeamListDto> getGptTeamList(HttpServletRequest servletRequest);
 
     List<TeamListResponseDto> getTeamsByCriteria(String sortBy, String teamName);
 

--- a/src/main/java/com/springboot/publicplace/service/impl/GPTServiceImpl.java
+++ b/src/main/java/com/springboot/publicplace/service/impl/GPTServiceImpl.java
@@ -46,7 +46,7 @@ public class GPTServiceImpl implements GPTService {
     public List<Message> getChatResponses(HttpServletRequest servletRequest, String prompt, HttpSession session) {
 
         // 팀 목록을 가져오는 요청
-        List<GPTTeamListDto> teamList = teamService.getTeamList(servletRequest);
+        List<GPTTeamListDto> teamList = teamService.getGptTeamList(servletRequest);
 
         // 팀 정보를 JSON 문자열로 변환
         String teamJson;

--- a/src/main/java/com/springboot/publicplace/service/impl/TeamServiceImpl.java
+++ b/src/main/java/com/springboot/publicplace/service/impl/TeamServiceImpl.java
@@ -4,10 +4,7 @@ import com.springboot.publicplace.config.security.JwtTokenProvider;
 import com.springboot.publicplace.dto.MemberDto;
 import com.springboot.publicplace.dto.ResultDto;
 import com.springboot.publicplace.dto.request.TeamRequestDto;
-import com.springboot.publicplace.dto.response.GPTTeamListDto;
-import com.springboot.publicplace.dto.response.TeamListResponseDto;
-import com.springboot.publicplace.dto.response.TeamResponseDto;
-import com.springboot.publicplace.dto.response.TeamRoleResponseDto;
+import com.springboot.publicplace.dto.response.*;
 import com.springboot.publicplace.entity.RoleType;
 import com.springboot.publicplace.entity.Team;
 import com.springboot.publicplace.entity.TeamUser;
@@ -176,45 +173,31 @@ public class TeamServiceImpl implements TeamService {
         );
     }
 
-//    @Override
-//    public List<TeamResponseDto> getRandomTeamList(HttpServletRequest servletRequest) {
-//        List<Team> teams = teamRepository.findAll();
-//        return teams.stream()
-//                .map(team -> {
-//                    // 팀원 리스트 생성
-//                    List<MemberDto> members = team.getTeamUsers().stream()
-//                            .map(teamUser -> new MemberDto(
-//                                    teamUser.getUser().getName(),
-//                                    teamUser.getUser().getNickname(),
-//                                    teamUser.getUser().getPosition(),
-//                                    teamUser.getRole(),
-//                                    teamUser.getUser().getAgeRange()
-//                            ))
-//                            .collect(Collectors.toList());
-//
-//                    // 팀원 수 계산
-//                    Long teamMemberCount = (long) members.size();
-//
-//                    // TeamResponseDto 생성 및 반환
-//                    return TeamResponseDto.builder()
-//                            .teamId(team.getTeamId())
-//                            .teamName(team.getTeamName())
-//                            .teamInfo(team.getTeamInfo())
-//                            .createdAt(team.getCreatedAt())
-//                            .teamLocation(team.getTeamLocation())
-//                            .latitude(team.getLatitude())
-//                            .longitude(team.getLongitude())
-//                            .teamImg(team.getTeamImg())
-//                            .activityDays(team.getActivityDays())
-//                            .teamMemberCount(teamMemberCount)  // 팀원 수 포함
-//                            .members(members)  // 팀원 리스트 포함
-//                            .build();
-//                })
-//                .collect(Collectors.toList());
-//    }
+    @Override
+    public List<TeamRandomListDto> getTeamList(HttpServletRequest servletRequest) {
+        List<Team> teams = teamRepository.findAll();
+        return teams.stream()
+                .map(team -> {
+                    Long teamMemberCount = (long) team.getTeamUsers().size();
+
+                    double averageAge = team.getAverageAge();
+
+                    // TeamResponseDto 생성 및 반환
+                    return TeamRandomListDto.builder()
+                            .teamId(team.getTeamId())
+                            .teamName(team.getTeamName())
+                            .createdAt(team.getCreatedAt())
+                            .teamLocation(team.getTeamLocation())
+                            .teamImg(team.getTeamImg())
+                            .teamMemberCount(teamMemberCount)  // 팀원 수 포함
+                            .averageAge(averageAge)
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
 
     @Override
-    public List<GPTTeamListDto> getTeamList(HttpServletRequest servletRequest) {
+    public List<GPTTeamListDto> getGptTeamList(HttpServletRequest servletRequest) {
         // 모든 팀을 가져옴
         List<Team> teams = teamRepository.findAll();
 


### PR DESCRIPTION
- GPT에 보내는 팀 정보는 controller 구현 X
- 기존에는 팀에 대한 모든 정보를 전송
- 수정 후에는 필요한 정보만 dto를 만들어 전송